### PR TITLE
Implement exec command

### DIFF
--- a/lib/checkstyle_filter/git/cli.rb
+++ b/lib/checkstyle_filter/git/cli.rb
@@ -29,6 +29,19 @@ module CheckstyleFilter
         puts ::CheckstyleFilter::Git::Filter.filter(data, git_diff)
       end
 
+      desc 'exec', 'Exec command `"git diff --no-color origin/master | iconv -f EUCJP -t UTF8"`'
+      def exec(command)
+        data = if !$stdin.tty?
+                 ARGV.clear
+                 ARGF.read
+               end
+
+        abort if !data || data.empty?
+
+        git_diff, _, _ = Open3.capture3(command)
+        puts ::CheckstyleFilter::Git::Filter.filter(data, git_diff)
+      end
+
       desc 'version', 'Show the CheckstyleFilter/Git version'
       map %w(-v --version) => :version
 


### PR DESCRIPTION
Hello. checkstyle_filter-git is good product.

I found one bug that following.

``` bash
⇒  vendor/bin/phpcs -n --report=checkstyle index.php | bundle exec checkstyle_filter-git diff origin/master
bundler: failed to load command: checkstyle_filter-git (/Users/shoyan/app/vendor/bundle/ruby/2.3.0/bin/checkstyle_filter-git)
ArgumentError: invalid byte sequence in UTF-8
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser/patches.rb:22:in `==='
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser/patches.rb:22:in `block in parse'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser/patches.rb:20:in `each'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser/patches.rb:20:in `each_with_index'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser/patches.rb:20:in `parse'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/git_diff_parser-2.3.0/lib/git_diff_parser.rb:13:in `parse'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/checkstyle_filter-git-1.0.3/lib/checkstyle_filter/git/filter.rb:8:in `filter'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/checkstyle_filter-git-1.0.3/lib/checkstyle_filter/git/cli.rb:29:in `diff'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/gems/checkstyle_filter-git-1.0.3/exe/checkstyle_filter-git:6:in `<top (required)>'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/bin/checkstyle_filter-git:23:in `load'
  /Users/shoyan/app/vendor/bundle/ruby/2.3.0/bin/checkstyle_filter-git:23:in `<top (required)>'
```

A character encoding of `index.php` is `EUC-JP`. 

I first had to customize the `diff` command. However, it did not work.
So I implemented `exec` command.

For example.

``` bash
$  vendor/bin/phpcs -n --report=checkstyle index.php | bundle exec checkstyle_filter-git exec "git diff --no-color origin/master | iconv -f EUCJP -t UTF8"
<?xml version='1.0' encoding='UTF-8'?>
<checkstyle version='2.6.1'>
<file name='/Users/shoyan/app/index.php'>
 <error column='5' line='9' message='Expected 1 space after closing parenthesis; found 0' severity='error' source='Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis'/>
</file>
</checkstyle>
```
