### PR TITLE
Update example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ git diff -z --name-only origin/master.. \
      --format RuboCop::Formatter::CheckstyleFormatter \
  | checkstyle_filter-git diff origin/master.. \
  | saddler report \
-     --require github/pull-request-comment-formatter \
-     --format Github::PullRequestCommentFormatter
+     --require saddler/reporter/github \
+     --reporter Saddler::Reporter::Github::PullRequestReviewComment
 ```
 
 ## Installation


### PR DESCRIPTION
The example command in README.md did not work (maybe because of update of saddler?).

```
$ bundle exec saddler report \
     --require github/pull-request-comment-formatter \
     --format Github::PullRequestCommentFormatter
ERROR: "saddler report" was called with arguments ["--format", "Github::PullRequestCommentFormatter"]
Usage: "saddler report"
```

So I updated it. 

see: https://github.com/packsaddle/ruby-saddler-reporter-github#usage